### PR TITLE
Load the state before checking whether the state values match.

### DIFF
--- a/src/FacebookRedirectLoginHelper.php
+++ b/src/FacebookRedirectLoginHelper.php
@@ -14,6 +14,7 @@ class FacebookRedirectLoginHelper extends BaseFacebookRedirectLoginHelper
      */
     protected function isValidRedirect()
     {
+        $this->loadState();
         return $this->getCode() && Request::get('state', null) == $this->state;
     }
 


### PR DESCRIPTION
When performing the isValidRedirect() check, it should load the state before attempting to check that the values match, otherwise $this->state will always be null.

Without this change it will endlessly redirect to and from Facebook.

This is pretty much how the base Facebook SDK does it too: https://github.com/facebook/facebook-php-sdk-v4/blob/4.0-dev/src/Facebook/FacebookRedirectLoginHelper.php#L214